### PR TITLE
ROCANA-3263 Go-grok builds on Windows with GCC 4.9.0

### DIFF
--- a/cgrok/grok.go
+++ b/cgrok/grok.go
@@ -2,6 +2,7 @@ package grok
 
 /*
 #cgo CFLAGS: -I. -std=gnu99
+#cgo windows CFLAGS: -IC:/msys64/mingw64/include
 #cgo windows LDFLAGS: -L. -lportablexdr -lws2_32
 #include "grok.h"
 */

--- a/cgrok/grok_capture.c
+++ b/cgrok/grok_capture.c
@@ -8,6 +8,50 @@
 
 char *EMPTYSTR = "";
 
+/* 
+ * public domain strtok_r() by Charlie Gordon
+ *
+ *   from comp.lang.c  9/14/2007
+ *
+ *      http://groups.google.com/group/comp.lang.c/msg/2ab1ecbb86646684
+ *
+ *     (Declaration that it's public domain):
+ *      http://groups.google.com/group/comp.lang.c/msg/7c7b39328fefab9c
+ *      
+ *      This is needed to build on Windows with GCC 4.9.0
+ */
+
+#ifdef _WIN64
+char* strtok_r(char *str, const char *delim, char **nextp) {
+    char *ret;
+
+    if (str == NULL)
+    {
+        str = *nextp;
+    }
+
+    str += strspn(str, delim);
+
+    if (*str == '\0')
+    {
+        return NULL;
+    }
+
+    ret = str;
+
+    str += strcspn(str, delim);
+
+    if (*str)
+    {
+        *str++ = '\0';
+    }
+
+    *nextp = str;
+
+    return ret;
+}
+#endif
+
 void grok_capture_init(grok_t *grok, grok_capture *gct) {
   gct->id = CAPTURE_NUMBER_NOT_SET;
   gct->pcre_capture_number = CAPTURE_NUMBER_NOT_SET;


### PR DESCRIPTION
The Go linker doesn't support recent versions of MinGW. This page has a pre-built binary of GCC 4.9.0 that works with the 1.3.3 Go linker: https://code.google.com/p/mingw-w64-dgn/

The process to set up a Windows build machine is:
- install an up-to-date MSYS from http://msys2.github.io/ to `C:\msys64`
- install MinGW-w64 from the link above to `C:\msys64`
- in the MSYS shell install `libportablexdr` but ignore dependencies: `pacman -Sdd mingw64/mingw-w64-x86_64-portablexdr`
