### PR TITLE
ROCANA-3602 Rename PCRE named groups to be proceeded with a colon

### DIFF
--- a/cgrok/grok_test.go
+++ b/cgrok/grok_test.go
@@ -157,7 +157,8 @@ func TestMatchIndices(t *testing.T) {
 	}
 }
 
-/* Support PCRE named captures, they just can't start with `_` */
+/* Support PCRE named captures: they can't start with `_`, and they're
+    prefixed with `:` */
 func TestPCRENamedCaptures(t *testing.T) {
 	g := New()
 	defer g.Free()
@@ -173,7 +174,7 @@ func TestPCRENamedCaptures(t *testing.T) {
 
 	captures := match.Captures()
 
-	if host := captures["word"][0]; host != "message" {
+	if host := captures[":word"][0]; host != "message" {
 		t.Fatal("word should be 'message'")
 	}
 	if len(captures["DAY"]) != 1 {
@@ -188,16 +189,16 @@ func TestPCRENamedCaptures(t *testing.T) {
 	if month := captures["MONTH"][0]; month != "November" {
 		t.Fatal("month should be 'November'")
 	}
-	if len(captures["year"]) != 1 {
+	if len(captures[":year"]) != 1 {
 		t.Fatal("Expected one group named year")
 	}
-        if year := captures["year"][0]; year != "2000" {
+        if year := captures[":year"][0]; year != "2000" {
 		t.Fatal("year should be '2000'")
 	}
-	if len(captures["host"]) != 1 {
+	if len(captures[":host"]) != 1 {
 		t.Fatal("Expected one group named host")
 	}
-        if host := captures["host"][0]; host != "ALLCAPSHOST" {
+        if host := captures[":host"][0]; host != "ALLCAPSHOST" {
 		t.Fatal("host should be 'ALLCAPSHOST'")
 	}
 	if len(captures["BASE10NUM"]) != 1 {

--- a/cgrok/grokre.c
+++ b/cgrok/grokre.c
@@ -428,12 +428,15 @@ static void grok_study_capture_map(grok_t *grok) {
          Make a new Grok capture group for each PCRE named group.
          We only use `grok_match_walk`, so we only need to populate
          `gct->pcre_capture_number` and `gct->name`.
+         PCRE named capture groups will be returned with a leading colon (':')
+         so they're always extracted.
       */ 
       gct = calloc(1, sizeof(grok_capture));
       size_t name_len = strlen(groupName);
-      char *name = malloc(name_len);
-      gct->name_len = name_len;
-      strncpy(name, groupName, name_len);
+      char *name = malloc(name_len + 1);
+      gct->name_len = name_len + 1;
+      *name = ':';
+      strncpy(name + 1, groupName, name_len);
       gct->name = name;
       gct->pcre_capture_number = stringnum;
       gct->id = -1 * i;


### PR DESCRIPTION
Prepend PCRE named group names with a colon, so that later when we split them the attribute name is correct.
