### PR TITLE
ROCANA-3777 Use a separate iterator for each concurrent Grok match

### DIFF
--- a/cgrok/grok.c
+++ b/cgrok/grok.c
@@ -21,7 +21,6 @@ void grok_init(grok_t *grok) {
   grok->re = NULL;
   grok->pattern = NULL;
   grok->full_pattern = NULL;
-  grok->pcre_capture_vector = NULL;
   grok->pcre_num_captures = 0;
   grok->max_capture_num = 0;
   grok->pcre_errptr = NULL;

--- a/cgrok/grok.h
+++ b/cgrok/grok.h
@@ -42,7 +42,6 @@ struct grok {
   TCTREE *patterns;
 
   pcre *re;
-  int *pcre_capture_vector;
   int pcre_num_captures;
   
   /* Data storage for named-capture (grok capture) information */

--- a/cgrok/grok_capture.c
+++ b/cgrok/grok_capture.c
@@ -133,14 +133,14 @@ void grok_capture_add(grok_t *grok, const grok_capture *gct) {
   /* end captures_by_subname */
 }
 
-const grok_capture *grok_capture_get_by_id(grok_t *grok, int id) {
+const grok_capture *grok_capture_get_by_id(const grok_t *grok, int id) {
   int unused_size;
   const grok_capture *gct;
   gct = tctreeget(grok->captures_by_id, &id, sizeof(id), &unused_size);
   return gct;
 }
 
-const grok_capture *grok_capture_get_by_name(grok_t *grok, const char *name) {
+const grok_capture *grok_capture_get_by_name(const grok_t *grok, const char *name) {
   int unused_size;
   const grok_capture *gct;
   const TCLIST *by_name_list;
@@ -155,7 +155,7 @@ const grok_capture *grok_capture_get_by_name(grok_t *grok, const char *name) {
   return gct;
 }
 
-const grok_capture *grok_capture_get_by_subname(grok_t *grok,
+const grok_capture *grok_capture_get_by_subname(const grok_t *grok,
                                                 const char *subname) {
   int unused_size;
   const grok_capture *gct;
@@ -257,17 +257,17 @@ void grok_capture_free(grok_capture *gct) {
 }
 
 /* this function will walk the captures_by_id table */
-void grok_capture_walk_init(grok_t *grok) {
-  tctreeiterinit(grok->captures_by_id);
+TCTREE_ITER *grok_capture_walk_init(const grok_t *grok) {
+  return tctreeiterinit(grok->captures_by_id);
 }
 
-const grok_capture *grok_capture_walk_next(grok_t *grok) {
+const grok_capture *grok_capture_walk_next(const TCTREE_ITER *iter, const grok_t *grok) {
   int id_size;
   int gct_size;
   int *id;
   const grok_capture *gct;
 
-  id = (int *)tctreeiternext(grok->captures_by_id, &id_size);
+  id = (int *)tctreeiternext(iter, &id_size);
   if (id == NULL) {
     grok_log(grok, LOG_CAPTURE, "walknext null");
     return NULL;

--- a/cgrok/grok_capture.h
+++ b/cgrok/grok_capture.h
@@ -9,15 +9,15 @@ void grok_capture_init(grok_t *grok, grok_capture *gct);
 void grok_capture_free(grok_capture *gct);
 
 void grok_capture_add(grok_t *grok, const grok_capture *gct);
-const grok_capture *grok_capture_get_by_id(grok_t *grok, int id);
-const grok_capture *grok_capture_get_by_name(grok_t *grok, const char *name);
-const grok_capture *grok_capture_get_by_subname(grok_t *grok,
+const grok_capture *grok_capture_get_by_id(const grok_t *grok, int id);
+const grok_capture *grok_capture_get_by_name(const grok_t *grok, const char *name);
+const grok_capture *grok_capture_get_by_subname(const grok_t *grok,
                                                 const char *subname);
 const grok_capture *grok_capture_get_by_capture_number(grok_t *grok,
                                                        int capture_number);
 
-void grok_capture_walk_init(grok_t *grok);
-const grok_capture *grok_capture_walk_next(grok_t *grok);
+TCTREE_ITER *grok_capture_walk_init(const grok_t *grok);
+const grok_capture *grok_capture_walk_next(const TCTREE_ITER *iter, const grok_t *grok);
 
 int grok_capture_set_extra(grok_t *grok, grok_capture *gct, void *extra);
 void _grok_capture_encode(grok_capture *gct, char **data_ret, int *size_ret);

--- a/cgrok/grok_discover.c
+++ b/cgrok/grok_discover.c
@@ -1,4 +1,4 @@
-#include <grok.h>
+#include "grok.h"
 #include "stringhelper.h"
 
 static int dgrok_init = 0;
@@ -112,12 +112,13 @@ void grok_discover(const grok_discover_t *gdt, /*grok_t *dest_grok, */
     int match = 0;
     grok_match_t gm;
     grok_match_t best_match;
+    TCTREE_ITER *tree_iter; 
 
     grok_log(gdt, LOG_DISCOVER, "%d: Round starting", rounds);
     grok_log(gdt, LOG_DISCOVER, "%d: String: %.*s", rounds, pattern_len, pattern);
     grok_log(gdt, LOG_DISCOVER, "%d: Offset: % *s^", rounds, offset - 1, " ");
 
-    tctreeiterinit(gdt->complexity_tree);
+    tree_iter = tctreeiterinit(gdt->complexity_tree);
     rounds++;
 
     replacements = 0;
@@ -132,7 +133,7 @@ void grok_discover(const grok_discover_t *gdt, /*grok_t *dest_grok, */
 
     char *cursor = pattern + offset;
 
-    while ((key = tctreeiternext(gdt->complexity_tree, &key_len)) != NULL) {
+    while ((key = tctreeiternext(tree_iter, &key_len)) != NULL) {
       const int *complexity = (const int *)key;
       int val_len;
       const grok_t *g = tctreeget(gdt->complexity_tree, key, sizeof(int), &val_len);
@@ -182,6 +183,8 @@ void grok_discover(const grok_discover_t *gdt, /*grok_t *dest_grok, */
         }
       } /* match == GROK_OK */
     } /* tctreeiternext(complexity_tree ...) */
+
+    tctreeiterfree(tree_iter);
 
     if (max_matchlen == 0) { /* No valid matches were found */
       if (first_match_endpos > 0) {

--- a/cgrok/grok_match.h
+++ b/cgrok/grok_match.h
@@ -24,6 +24,12 @@ typedef struct grok_match {
 
   /** End position of match. */
   int end;
+
+  /** Iterator for grok_match_walk */
+  TCTREE_ITER *iter;
+  
+  /** PCRE capture vector for the match */
+  int *pcre_capture_vector;
 } grok_match_t;
 
 const grok_capture * grok_match_get_named_capture(const grok_match_t *gm,
@@ -31,10 +37,11 @@ const grok_capture * grok_match_get_named_capture(const grok_match_t *gm,
 int grok_match_get_named_substring(const grok_match_t *gm, const char *name,
                                    const char **substr, int *len);
 
-void grok_match_walk_init(const grok_match_t *gm);
-int grok_match_walk_next(const grok_match_t *gm,
+void grok_match_walk_init(grok_match_t *gm);
+int grok_match_walk_next(grok_match_t *gm,
                          char **name, int *namelen,
                          const char **substr, int *substrlen);
-void grok_match_walk_end(const grok_match_t *gm);
+void grok_match_walk_end(grok_match_t *gm);
 
+void grok_match_free(grok_match_t *gm);
 #endif /*  _GROK_MATCH_H_ */

--- a/cgrok/grok_pattern.c
+++ b/cgrok/grok_pattern.c
@@ -13,11 +13,13 @@ TCLIST *grok_pattern_name_list(const grok_t *grok) {
   TCTREE *patterns = grok->patterns;
   names = tclistnew();
 
-  tctreeiterinit(patterns);
+  TCTREE_ITER *list_iter = tctreeiterinit(patterns);
 
-  while ((data = tctreeiternext(patterns, &datalen)) != NULL) {
+  while ((data = tctreeiternext(list_iter, &datalen)) != NULL) {
     tclistpush(names, data, datalen);
   }
+
+  tctreeiterfree(list_iter);
 
   return names;
 }

--- a/cgrok/tree.h
+++ b/cgrok/tree.h
@@ -7,8 +7,9 @@ typedef struct TCTREE TCTREE;
 // A shim to use dictlib trees instead of TC
 struct TCTREE {
   dict *dict;
-  dict_itor *iter;
 };
+
+typedef dict_itor TCTREE_ITER;
 
 // A replacement for the 32-bit int key comparator
 int tccmpint32(const void* k1, const void* k2);
@@ -18,8 +19,9 @@ int dict_var_str_cmp(const void* k1, const void* k2);
 
 TCTREE *tctreenew(void);
 TCTREE *tctreenew2(dict_compare_func cp, void *cmpop);
-void tctreeiterinit(TCTREE *tree);
-const void *tctreeiternext(TCTREE *tree, int *sp);
+TCTREE_ITER *tctreeiterinit(const TCTREE *tree);
+const void *tctreeiternext(const TCTREE_ITER *iter, int *sp);
+void tctreeiterfree(TCTREE_ITER *iter);
 void tctreeput(TCTREE *tree, const void *kbuf, int ksiz, const void *vbuf, int vsiz);
 bool tctreeputkeep(TCTREE *tree, const void *kbuf, int ksiz, const void *vbuf, int vsiz);
 const void *tctreeget(TCTREE *tree, const void *kbuf, int ksiz, int *sp);


### PR DESCRIPTION
We were seeing incorrect results and stack traces when trying to use the same compiled Grok in multiple goroutines concurrently. Grok was originally only designed for single-threaded use.

Grok originally used Tokyo Cabinet, which only allows for a single iterator per tree. I dropped in libdict as a replacement, but kept the Grok side the same, so there was one iterator per Grok pattern. This became a problem when multiple matches tried to walk the list of named groups concurrently.

Since libdict supports multiple iterators at a time, I just gave each match it's own iterator. Now multiple concurrent matches don't affect each other.

Grok was also sharing a single PCRE vector across all matches - an `int[]` which stores the beginning and end of each substring. Changed this to a vector per match - the allocation is a little more expensive, but it's still cheaper than recompiling the whole grok for each match.

Cleaned up some `const`ness issues to make the build a bit cleaner, since we've been bitten by build warnings before.
