### PR TITLE
ROCANA-4044 Changes to make Grok faster

### DIFF
--- a/cgrok/grok.go
+++ b/cgrok/grok.go
@@ -71,11 +71,11 @@ func (grok *Grok) AddPatternsFromFile(path string) error {
 	return nil
 }
 
-func (grok *Grok) Compile(pattern string) error {
+func (grok *Grok) Compile(pattern string, onlyRenamed bool) error {
 	p := C.CString(pattern)
 	defer C.free(unsafe.Pointer(p))
 
-	ret := C.grok_compile(grok.g, p)
+	ret := C.grok_compile(grok.g, p, C.int(boolToInt(onlyRenamed)))
 	if ret != GROK_OK {
 		return errors.New(fmt.Sprintf("Failed to compile: %s", C.GoString(grok.g.errstr)))
 	}
@@ -138,7 +138,7 @@ func (pile *Pile) AddPattern(name, str string) {
 	pile.Patterns[name] = str
 }
 
-func (pile *Pile) Compile(pattern string) error {
+func (pile *Pile) Compile(pattern string, onlyRenamed bool) error {
 	grok := New()
 	if grok == nil {
 		return errors.New("Unable to initialize grok!")
@@ -154,7 +154,7 @@ func (pile *Pile) Compile(pattern string) error {
 		}
 	}
 
-	grok.Compile(pattern)
+	grok.Compile(pattern, onlyRenamed)
 	pile.Groks = append(pile.Groks, grok)
 
 	return nil
@@ -239,4 +239,11 @@ func (match *Match) CaptureIntoMap(captures map[string]string) {
    library's `FindIndex`. */
 func (match *Match) FindIndex() []int {
 	return []int{int(match.gm.start), int(match.gm.end)}
+}
+
+func boolToInt(b bool) int {
+  if b {
+    return 1
+  }
+  return 0
 }

--- a/cgrok/grok.h
+++ b/cgrok/grok.h
@@ -216,7 +216,7 @@ const char *grok_version();
  * @param grok the grok_t instance to compile into.
  * @param pattern the string regexp pattern to compile.
  */
-int grok_compile(grok_t *grok, const char *pattern);
+int grok_compile(grok_t *grok, const char *pattern, int renamed_only);
 
 /**
  * Compile a pattern with known length.
@@ -225,7 +225,7 @@ int grok_compile(grok_t *grok, const char *pattern);
  * @param length the length of the pattern
  * @see grok_compile()
  */
-int grok_compilen(grok_t *grok, const char *pattern, int length);
+int grok_compilen(grok_t *grok, const char *pattern, int length, int renamed_only);
 
 /**
  * Execute against a string input.

--- a/cgrok/grok_capture.c
+++ b/cgrok/grok_capture.c
@@ -68,10 +68,14 @@ void grok_capture_init(grok_t *grok, grok_capture *gct) {
   gct->extra.extra_val = NULL;
 }
 
-void grok_capture_add(grok_t *grok, const grok_capture *gct) {
+void grok_capture_add(grok_t *grok, const grok_capture *gct, int only_renamed) {
   grok_log(grok, LOG_CAPTURE, 
            "Adding pattern '%s' as capture %d (pcrenum %d)",
            gct->name, gct->id, gct->pcre_capture_number);
+
+  if (only_renamed && strstr(gct->name, ":") == NULL) {
+    return;
+  }
 
   /* Primary key is id */
   tctreeput(grok->captures_by_id, &(gct->id), sizeof(gct->id),

--- a/cgrok/grok_capture.h
+++ b/cgrok/grok_capture.h
@@ -8,7 +8,7 @@
 void grok_capture_init(grok_t *grok, grok_capture *gct);
 void grok_capture_free(grok_capture *gct);
 
-void grok_capture_add(grok_t *grok, const grok_capture *gct);
+void grok_capture_add(grok_t *grok, const grok_capture *gct, int only_renamed);
 const grok_capture *grok_capture_get_by_id(const grok_t *grok, int id);
 const grok_capture *grok_capture_get_by_name(const grok_t *grok, const char *name);
 const grok_capture *grok_capture_get_by_subname(const grok_t *grok,

--- a/cgrok/grok_discover.c
+++ b/cgrok/grok_discover.c
@@ -9,10 +9,10 @@ static int complexity(const grok_t *grok);
 static void grok_discover_global_init() {
   dgrok_init = 1;
   grok_init(&global_discovery_req1_grok);
-  grok_compile(&global_discovery_req1_grok, ".\\b.");
+  grok_compile(&global_discovery_req1_grok, ".\\b.", false);
 
   grok_init(&global_discovery_req2_grok);
-  grok_compile(&global_discovery_req2_grok, "%\\{[^}]+\\}");
+  grok_compile(&global_discovery_req2_grok, "%\\{[^}]+\\}", false);
 }
 
 grok_discover_t *grok_discover_new(grok_t *source_grok) {
@@ -55,7 +55,7 @@ void grok_discover_init(grok_discover_t *gdt, grok_t *source_grok) {
       perror("asprintf failed");
       abort();
     }
-    grok_compile(g, gpattern);
+    grok_compile(g, gpattern, false);
     *key = complexity(g);
 
     /* Low complexity should be skipped */

--- a/cgrok/grok_test.go
+++ b/cgrok/grok_test.go
@@ -19,7 +19,7 @@ func TestDayCompile(t *testing.T) {
 	defer g.Free()
 
 	pattern := "%{DAY}"
-	err := g.Compile(pattern)
+	err := g.Compile(pattern, false)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -32,7 +32,7 @@ func TestDayCompileAndMatch(t *testing.T) {
 	g.AddPatternsFromFile("../patterns/base")
 	text := "Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157"
 	pattern := "%{DAY}"
-	err := g.Compile(pattern)
+	err := g.Compile(pattern, false)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -52,7 +52,7 @@ func TestMatchCaptures(t *testing.T) {
 	g.AddPatternsFromFile("../patterns/base")
 	text := "Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157"
 	pattern := "%{DAY}"
-	g.Compile(pattern)
+	g.Compile(pattern, false)
 	match := g.Match(text)
 	if match == nil {
 		t.Fatal("Unable to find match!")
@@ -71,7 +71,7 @@ func TestURICaptures(t *testing.T) {
 	g.AddPatternsFromFile("../patterns/base")
 	text := "https://www.google.com/search?q=moose&sugexp=chrome,mod=16&sourceid=chrome&ie=UTF-8"
 	pattern := "%{URI}"
-	g.Compile(pattern)
+	g.Compile(pattern, false)
 	match := g.Match(text)
 	if match == nil {
 		t.Fatal("Unable to find match!")
@@ -95,7 +95,7 @@ func TestDiscovery(t *testing.T) {
 
 	text := "1.2.3.4"
 	discovery := g.Discover(text)
-	g.Compile(discovery)
+	g.Compile(discovery, false)
 	captures := g.Match(text).Captures()
 	if ip := captures["IP"][0]; ip != text {
 		t.Fatal("IP should be 1.2.3.4")
@@ -109,7 +109,7 @@ func TestPileMatching(t *testing.T) {
 	p.AddPattern("foo", ".*(foo).*")
 	p.AddPattern("bar", ".*(bar).*")
 
-	p.Compile("%{bar}")
+	p.Compile("%{bar}", false)
 
 	grok, match := p.Match("bar")
 
@@ -129,7 +129,7 @@ func TestPileAddPatternsFromFile(t *testing.T) {
 	defer p.Free()
 
 	p.AddPatternsFromFile("../patterns/base")
-	p.Compile("%{DAY}")
+	p.Compile("%{DAY}", false)
 
 	text := "Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157"
 
@@ -145,7 +145,7 @@ func TestPileAddPatternsFromFile(t *testing.T) {
 func TestMatchIndices(t *testing.T) {
 	text := "Tue May 15 11:21:42 [conn1047685] moveChunk deleted: May 7157"
 	g := New()
-	g.Compile("May")
+	g.Compile("May", false)
 
 	match := g.Match(text)
 	
@@ -167,7 +167,7 @@ func TestPCRENamedCaptures(t *testing.T) {
 	g.AddPatternsFromFile("../patterns/base")
 	text := "message - Tue November 2000 ALLCAPSHOST 12345"
 	pattern := "(?P<word>[a-z]*) - %{DAY} %{MONTH} (?P<year>[0-9]*) (?P<host>[A-Z]*) %{BASE10NUM}"
-	g.Compile(pattern)
+	g.Compile(pattern, false)
 	match := g.Match(text)
 	if match == nil {
 		t.Fatal("Unable to find match!")
@@ -220,7 +220,7 @@ func TestConcurrentCaptures(t *testing.T) {
 	text1 := "1124412d476eb4e8c9b691cacfa51bb990eff8169c3337e0be688c1caf1bdaf0 releases.rocana.com [11/Apr/2015:03:27:40 +0000] 10.220.7.37 arn:aws:iam::368902385577:user/mark FC206D08A83F5300 REST.POST.UPLOADS scalingdata-0.7.0.tar.gz \"POST /releases.rocana.com/scalingdata-0.7.0.tar.gz?uploads HTTP/1.1\" 200 - 370 - 8 7 \"-\" \"S3Console/0.4\" -"
 	text2 := "1124412d476eb4e8c9b691cacfa51bb990eff8169c3337e0be688c1caf1bdaf0 releases.rocana.com [24/Jul/2015:01:34:43 +0000] 135.23.112.88 - A2AD9CC02C12642F REST.HEAD.OBJECT 1.2.0/rocana-installer-1.2.0.bin.asc \"HEAD /1.2.0/rocana-installer-1.2.0.bin.asc HTTP/1.1\" 200 - - 836 7 - \"-\" \"curl/7.37.1\" -"
 	pattern := "%{WORD:owner} %{NOTSPACE:bucket} \\[%{HTTPDATE:timestamp}\\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:\"%{S3_REQUEST_LINE}\"|-) (?:%{INT:response}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes}|-) (?:%{INT:object_size}|-) (?:%{INT:request_time_ms}|-) (?:%{INT:turnaround_time_ms}|-) (?:%{QS:referrer}|-) (?:\"?%{QS:agent}\"?|-) (?:-|%{NOTSPACE:version_id})"
-	g.Compile(pattern)
+	g.Compile(pattern, false)
 	var s sync.WaitGroup
 	for i := 0 ; i< 10000; i++ {
 		s.Add(1)	
@@ -268,7 +268,6 @@ func TestConcurrentCaptures(t *testing.T) {
 	}
 	s.Wait()
 }
-
 /* Test extracting into an existing map. Only renamed sub-expressions
    and all PCRE named groups, should be included. */
 func TestCaptureIntoMap(t *testing.T) {
@@ -279,7 +278,7 @@ func TestCaptureIntoMap(t *testing.T) {
 
 	text := "message - Tue November 2000 ALLCAPSHOST 12345"
 	pattern := "(?P<word>[a-z]*) - %{DAY:day} %{MONTH} (?P<year>[0-9]*) (?P<host>[A-Z]*) %{BASE10NUM:number}"
-	g.Compile(pattern)
+	g.Compile(pattern, true)
 	match := g.Match(text)
 	if match == nil {
 		t.Fatal("Unable to find match!")
@@ -306,5 +305,54 @@ func TestCaptureIntoMap(t *testing.T) {
 	}
 	if num := captures["number"]; num != "12345" {
 		t.Fatal("`number` should be '12345'")
+	}
+}
+
+func BenchmarkOldGrok(b *testing.B) {
+	g := New()
+	defer g.Free()
+
+	g.AddPatternsFromFile("../patterns/base")
+	g.AddPattern("S3_REQUEST_LINE", "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest}) (?P<pcre_named>.*)")
+	text := "1124412d476eb4e8c9b691cacfa51bb990eff8169c3337e0be688c1caf1bdaf0 releases.rocana.com [11/Apr/2015:03:27:40 +0000] 10.220.7.37 arn:aws:iam::368902385577:user/mark FC206D08A83F5300 REST.POST.UPLOADS scalingdata-0.7.0.tar.gz \"POST /releases.rocana.com/scalingdata-0.7.0.tar.gz?uploads HTTP/1.1\" 200 - 370 - 8 7 \"-\" \"S3Console/0.4\" -"
+	pattern := "%{WORD:owner} %{NOTSPACE:bucket} \\[%{HTTPDATE:timestamp}\\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:\"%{S3_REQUEST_LINE}\"|-) (?:%{INT:response}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes}|-) (?:%{INT:object_size}|-) (?:%{INT:request_time_ms}|-) (?:%{INT:turnaround_time_ms}|-) (?:%{QS:referrer}|-) (?:\"?%{QS:agent}\"?|-) (?:-|%{NOTSPACE:version_id})"
+	g.Compile(pattern, false)
+	for i := 0; i < b.N; i++ {
+		m := g.Match(text)
+		m.Captures()
+		m.Free()
+	}
+}
+
+func BenchmarkNewGrok(b *testing.B) {
+	g := New()
+	defer g.Free()
+
+	g.AddPatternsFromFile("../patterns/base")
+	g.AddPattern("S3_REQUEST_LINE", "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest}) (?P<pcre_named>.*)")
+	text := "1124412d476eb4e8c9b691cacfa51bb990eff8169c3337e0be688c1caf1bdaf0 releases.rocana.com [11/Apr/2015:03:27:40 +0000] 10.220.7.37 arn:aws:iam::368902385577:user/mark FC206D08A83F5300 REST.POST.UPLOADS scalingdata-0.7.0.tar.gz \"POST /releases.rocana.com/scalingdata-0.7.0.tar.gz?uploads HTTP/1.1\" 200 - 370 - 8 7 \"-\" \"S3Console/0.4\" -"
+	pattern := "%{WORD:owner} %{NOTSPACE:bucket} \\[%{HTTPDATE:timestamp}\\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:\"%{S3_REQUEST_LINE}\"|-) (?:%{INT:response}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes}|-) (?:%{INT:object_size}|-) (?:%{INT:request_time_ms}|-) (?:%{INT:turnaround_time_ms}|-) (?:%{QS:referrer}|-) (?:\"?%{QS:agent}\"?|-) (?:-|%{NOTSPACE:version_id})"
+	g.Compile(pattern, true)
+	for i := 0; i < b.N; i++ {
+		m := g.Match(text)
+		m.Captures()
+		m.Free()
+	}
+}
+
+func BenchmarkNewGrokIntoMap(b *testing.B) {
+	g := New()
+	defer g.Free()
+
+	g.AddPatternsFromFile("../patterns/base")
+	g.AddPattern("S3_REQUEST_LINE", "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest}) (?P<pcre_named>.*)")
+	text := "1124412d476eb4e8c9b691cacfa51bb990eff8169c3337e0be688c1caf1bdaf0 releases.rocana.com [11/Apr/2015:03:27:40 +0000] 10.220.7.37 arn:aws:iam::368902385577:user/mark FC206D08A83F5300 REST.POST.UPLOADS scalingdata-0.7.0.tar.gz \"POST /releases.rocana.com/scalingdata-0.7.0.tar.gz?uploads HTTP/1.1\" 200 - 370 - 8 7 \"-\" \"S3Console/0.4\" -"
+	pattern := "%{WORD:owner} %{NOTSPACE:bucket} \\[%{HTTPDATE:timestamp}\\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:\"%{S3_REQUEST_LINE}\"|-) (?:%{INT:response}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes}|-) (?:%{INT:object_size}|-) (?:%{INT:request_time_ms}|-) (?:%{INT:turnaround_time_ms}|-) (?:%{QS:referrer}|-) (?:\"?%{QS:agent}\"?|-) (?:-|%{NOTSPACE:version_id})"
+	g.Compile(pattern, true)
+	attr := make(map[string]string)
+	for i := 0; i < b.N; i++ {
+		m := g.Match(text)
+		m.CaptureIntoMap(attr)
+		m.Free()
 	}
 }

--- a/cgrok/predicates.c
+++ b/cgrok/predicates.c
@@ -81,7 +81,7 @@ static void grok_predicate_regexp_global_init(void) {
 }
 
 int grok_predicate_regexp_init(grok_t *grok, grok_capture *gct,
-                               const char *args, int args_len) {
+                               const char *args, int args_len, int renamed_only) {
   #define REGEXP_OVEC_SIZE 6
   int capture_vector[REGEXP_OVEC_SIZE * 3];
   int ret; 
@@ -110,7 +110,7 @@ int grok_predicate_regexp_init(grok_t *grok, grok_capture *gct,
 
   grok_log(grok, LOG_PREDICATE, "Regexp predicate is '%s'", gprt->pattern);
   grok_clone(&gprt->gre, grok);
-  ret = grok_compile(&gprt->gre, gprt->pattern);
+  ret = grok_compile(&gprt->gre, gprt->pattern, renamed_only);
 
   gprt->negative_match = (args[capture_vector[2]] == '!');
 
@@ -135,7 +135,7 @@ int grok_predicate_regexp_init(grok_t *grok, grok_capture *gct,
   gct->predicate_func_name = string_ndup("grok_predicate_regexp", constlen);
   gct->predicate_func_name_len = constlen;
   grok_capture_set_extra(grok, gct, gprt);
-  grok_capture_add(grok, gct);
+  grok_capture_add(grok, gct, renamed_only);
 
   return 0;
 }
@@ -179,7 +179,7 @@ int grok_predicate_regexp(grok_t *grok, const grok_capture *gct,
 }
 
 int grok_predicate_numcompare_init(grok_t *grok, grok_capture *gct,
-                                   const char *args, int args_len) {
+                                   const char *args, int args_len, int renamed_only) {
   grok_predicate_numcompare_t *gpnt;
 
   /* I know I said that args is a const char, but we need to modify the string
@@ -218,7 +218,7 @@ int grok_predicate_numcompare_init(grok_t *grok, grok_capture *gct,
   gct->predicate_func_name = string_ndup("grok_predicate_numcompare", constlen);
   gct->predicate_func_name_len = constlen;
   grok_capture_set_extra(grok, gct, gpnt);
-  grok_capture_add(grok, gct);
+  grok_capture_add(grok, gct, renamed_only);
   return 0;
 }
 
@@ -247,7 +247,7 @@ int grok_predicate_numcompare(grok_t *grok, const grok_capture *gct,
 }
 
 int grok_predicate_strcompare_init(grok_t *grok, grok_capture *gct,
-                                   const char *args, int args_len) {
+                                   const char *args, int args_len, int renamed_only) {
   grok_predicate_strcompare_t *gpst;
   int pos;
 
@@ -276,7 +276,7 @@ int grok_predicate_strcompare_init(grok_t *grok, grok_capture *gct,
   gct->predicate_func_name = string_ndup("grok_predicate_strcompare", constlen);
   gct->predicate_func_name_len = constlen;
   grok_capture_set_extra(grok, gct, gpst);
-  grok_capture_add(grok, gct);
+  grok_capture_add(grok, gct, renamed_only);
 
   return 0;
 }

--- a/cgrok/predicates.h
+++ b/cgrok/predicates.h
@@ -9,11 +9,11 @@
  */
 
 int grok_predicate_regexp_init(grok_t *grok, grok_capture *gct,
-                               const char *args, int args_len);
+                               const char *args, int args_len, int renamed_only);
 int grok_predicate_numcompare_init(grok_t *grok, grok_capture *gct,
-                                   const char *args, int args_len);
+                                   const char *args, int args_len, int renamed_only);
 int grok_predicate_strcompare_init(grok_t *grok, grok_capture *gct,
-                                   const char *args, int args_len);
+                                   const char *args, int args_len, int renamed_only);
 
 
 #endif /* _PREDICATES_H_ */


### PR DESCRIPTION
Depends on ROCANA-3625, which extracts attributes into an existing map to reduce copying.

Adds an argument to skip extracting named groups unless they've been renamed. This saves time in walking the captures map.

Reduction in CPU usage (for the Apache Combined Log format pattern) is >50%:

```
BenchmarkOldGrok       50000         31428 ns/op
BenchmarkNewGrok      100000         22046 ns/op
BenchmarkNewGrokToMap     100000         14208 ns/op
```
