### PR TITLE
ROCANA-4045 Fixes to produce less garbage strings

### DIFF
--- a/cgrok/grok_match.c
+++ b/cgrok/grok_match.c
@@ -67,6 +67,26 @@ int grok_match_walk_next(grok_match_t *gm,
   return 0;
 }
 
+int grok_match_walk_next_offsets(grok_match_t *gm,
+                         char **name, int *namelen,
+                         int *substrIndex, int *substrlen) {
+  const grok_capture *gct;
+  int start, end;
+  gct = grok_capture_walk_next(gm->iter, gm->grok);
+  if (gct == NULL) {
+    return 1;
+  }
+
+  *namelen = gct->name_len;
+  *name = gct->name;
+
+  start = (gm->pcre_capture_vector[gct->pcre_capture_number * 2]);
+  end = (gm->pcre_capture_vector[gct->pcre_capture_number * 2 + 1]);
+  *substrIndex = start;
+  *substrlen = (end - start);
+  return 0;
+}
+
 void grok_match_walk_end(grok_match_t *gm) {
   if (gm->iter != NULL) {
     tctreeiterfree(gm->iter);

--- a/cgrok/grok_match.h
+++ b/cgrok/grok_match.h
@@ -41,6 +41,10 @@ void grok_match_walk_init(grok_match_t *gm);
 int grok_match_walk_next(grok_match_t *gm,
                          char **name, int *namelen,
                          const char **substr, int *substrlen);
+int grok_match_walk_next_offsets(grok_match_t *gm,
+                         char **name, int *namelen,
+                         int *substrIndex, int *substrlen);
+
 void grok_match_walk_end(grok_match_t *gm);
 
 void grok_match_free(grok_match_t *gm);

--- a/cgrok/grok_test.go
+++ b/cgrok/grok_test.go
@@ -268,14 +268,12 @@ func TestConcurrentCaptures(t *testing.T) {
 	}
 	s.Wait()
 }
-/* Test extracting into an existing map. Only renamed sub-expressions
-   and all PCRE named groups, should be included. */
-func TestCaptureIntoMap(t *testing.T) {
+
+func TestRenamedOnly(t *testing.T) {
 	g := New()
 	defer g.Free()
 
 	g.AddPatternsFromFile("../patterns/base")
-
 	text := "message - Tue November 2000 ALLCAPSHOST 12345"
 	pattern := "(?P<word>[a-z]*) - %{DAY:day} %{MONTH} (?P<year>[0-9]*) (?P<host>[A-Z]*) %{BASE10NUM:number}"
 	g.Compile(pattern, true)


### PR DESCRIPTION
Based on ROCANA-3625 and the fix to pare out un-extracted named groups. This change uses slices from the original subject string, to reduce the number of heap allocated strings. It also caches the names of the capture groups, because these are always the same for every match of a given grok.

Benchmark results (new method):

```
BenchmarkOldGrok       50000         35870 ns/op        6796 B/op         60 allocs/op
BenchmarkNewGrok      100000         24360 ns/op        3448 B/op         43 allocs/op
BenchmarkNewGrokIntoMap   200000         13959 ns/op         136 B/op          3 allocs/op
```

Benchmark results (old method):

```
BenchmarkOldGrok       50000         36978 ns/op        7380 B/op         87 allocs/op
BenchmarkNewGrok      100000         24807 ns/op        3924 B/op         64 allocs/op
BenchmarkNewGrokIntoMap   100000         16363 ns/op         982 B/op         37 allocs/op
```
