### PR TITLE
ROCANA-4303 Don't use scanf

### DIFF
--- a/cgrok/grok.h
+++ b/cgrok/grok.h
@@ -125,8 +125,8 @@ extern int g_cap_definition;
 /** grok_exec did not match your string */
 #define GROK_ERROR_NOMATCH 7
 
-#define CAPTURE_ID_LEN 4
-#define CAPTURE_FORMAT "%04x"
+#define CAPTURE_ID_LEN 6
+#define CAPTURE_FORMAT "0x%04x"
 
 #include "grok_logging.h"
 

--- a/cgrok/grok_test.go
+++ b/cgrok/grok_test.go
@@ -148,7 +148,7 @@ func TestMatchIndices(t *testing.T) {
 	g.Compile("May", false)
 
 	match := g.Match(text)
-	
+
 	idx := match.FindIndex()
 	if idx[0] != 4 {
 		t.Fatal("Expected starting index 4, got", idx[0])
@@ -159,7 +159,7 @@ func TestMatchIndices(t *testing.T) {
 }
 
 /* Support PCRE named captures: they can't start with `_`, and they're
-    prefixed with `:` */
+   prefixed with `:` */
 func TestPCRENamedCaptures(t *testing.T) {
 	g := New()
 	defer g.Free()
@@ -210,6 +210,30 @@ func TestPCRENamedCaptures(t *testing.T) {
 	}
 }
 
+/* Test PCRE named groups of various lengths */
+func TestPCRENamedCaptureHexNum(t *testing.T) {
+	g := New()
+	defer g.Free()
+
+	g.AddPatternsFromFile("../patterns/base")
+	text := "ALLCAPSHOST"
+	pattern := "(?P<deadbeef>[A-Z]*)"
+	g.Compile(pattern, false)
+	match := g.Match(text)
+	if match == nil {
+		t.Fatal("Unable to find match!")
+	}
+
+	captures := match.Captures()
+
+	if len(captures[":deadbeef"]) != 1 {
+		t.Fatal("Expected one group named deadbeef")
+	}
+	if host := captures[":deadbeef"][0]; host != "ALLCAPSHOST" {
+		t.Fatal("deadbeef should be 'ALLCAPSHOST'")
+	}
+}
+
 /* Test multiple goroutines using the same Grok concurrently - we use a separate iterator and PCRE vector per match now */
 func TestConcurrentCaptures(t *testing.T) {
 	g := New()
@@ -222,25 +246,25 @@ func TestConcurrentCaptures(t *testing.T) {
 	pattern := "%{WORD:owner} %{NOTSPACE:bucket} \\[%{HTTPDATE:timestamp}\\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:\"%{S3_REQUEST_LINE}\"|-) (?:%{INT:response}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes}|-) (?:%{INT:object_size}|-) (?:%{INT:request_time_ms}|-) (?:%{INT:turnaround_time_ms}|-) (?:%{QS:referrer}|-) (?:\"?%{QS:agent}\"?|-) (?:-|%{NOTSPACE:version_id})"
 	g.Compile(pattern, false)
 	var s sync.WaitGroup
-	for i := 0 ; i< 10000; i++ {
-		s.Add(1)	
-		go func(){
+	for i := 0; i < 10000; i++ {
+		s.Add(1)
+		go func() {
 			defer s.Done()
 			for j := 0; j < 5; j++ {
-				if i % 2 == 0 {
+				if i%2 == 0 {
 					match := g.Match(text1)
 					if match == nil {
 						t.Fatal("Unable to match string 1")
 					}
 					captures := match.Captures()
 					if captures["HTTPDATE:timestamp"][0] != "11/Apr/2015:03:27:40 +0000" {
-						t.Fatal("Got unexpected timestamp "+captures["HTTPDATE:timestamp"][0])
-					}	
- 					if captures["QS:agent"][0] != "\"S3Console/0.4\"" {
+						t.Fatal("Got unexpected timestamp " + captures["HTTPDATE:timestamp"][0])
+					}
+					if captures["QS:agent"][0] != "\"S3Console/0.4\"" {
 						t.Fatal("Got unexpected agent " + captures["QS:agent"][0])
 					}
 					if captures["INT:bytes"][0] != "370" {
-						t.Fatal("Got unexpected bytes "+captures["INT:bytes"][0])
+						t.Fatal("Got unexpected bytes " + captures["INT:bytes"][0])
 					}
 					match.Free()
 				} else {
@@ -250,16 +274,16 @@ func TestConcurrentCaptures(t *testing.T) {
 					}
 					captures := match.Captures()
 					if captures["HTTPDATE:timestamp"][0] != "24/Jul/2015:01:34:43 +0000" {
-						t.Fatal("Got unexpected timestamp "+captures["HTTPDATE:timestamp"][0])
-					}	
- 					if captures["QS:agent"][0] != "\"curl/7.37.1\"" {
-						t.Fatal("Got unexpected agent "+captures["QS:agent"][0])
+						t.Fatal("Got unexpected timestamp " + captures["HTTPDATE:timestamp"][0])
+					}
+					if captures["QS:agent"][0] != "\"curl/7.37.1\"" {
+						t.Fatal("Got unexpected agent " + captures["QS:agent"][0])
 					}
 					if captures["INT:bytes"][0] != "" {
-						t.Fatal("Got unexpected bytes "+captures["INT:bytes"][0])
+						t.Fatal("Got unexpected bytes " + captures["INT:bytes"][0])
 					}
 					if captures["INT:object_size"][0] != "836" {
-						t.Fatal("Got unexpected size "+captures["INT:object_size"][0])
+						t.Fatal("Got unexpected size " + captures["INT:object_size"][0])
 					}
 					match.Free()
 				}
@@ -284,7 +308,7 @@ func TestRenamedOnly(t *testing.T) {
 	captures := make(map[string]string)
 	match.StartIterator()
 	for match.Next() {
-		name, substr :=  match.Group()
+		name, substr := match.Group()
 		captures[name] = substr
 	}
 	match.EndIterator()
@@ -356,7 +380,7 @@ func BenchmarkNewGrokIterator(b *testing.B) {
 		m := g.Match(text)
 		m.StartIterator()
 		for m.Next() {
-			m.Group()	
+			m.Group()
 		}
 		m.EndIterator()
 		m.Free()


### PR DESCRIPTION
It turns out `sscanf` is only supplied in glibc 2.7 or higher. Use a custom parsing function to get the capture ID.

`objdump` shows the newest symbol we depend on now is from glibc 2.3:

```
Thu Dec 03 17:53:39 vagrant ~ 
1002 $ objdump -T /vagrant/rocana-agent | fgrep GLIBC
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 printf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memset
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 ftell
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 snprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 abort
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fseek
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 exit
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __assert_fail
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getaddrinfo
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strncmp
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fopen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __libc_start_main
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sigfillset
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getpid
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 pthread_attr_destroy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 vfprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fputc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 freeaddrinfo
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strlen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 pthread_create
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3   __ctype_b_loc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 pthread_attr_getstacksize
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strerror
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strtol
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memmove
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strchr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fread
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 setenv
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __errno_location
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 asprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strcmp
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 calloc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 feof
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fclose
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 random
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strncpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 pthread_attr_init
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 stderr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 pthread_sigmask
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fwrite
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 realloc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 perror
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 gai_strerror
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strtod
0000000000407160      DF *UND*  0000000000000000  GLIBC_2.2.5 malloc
00000000004071f0      DF *UND*  0000000000000000  GLIBC_2.2.5 free
```
